### PR TITLE
fix: remove ownerref

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0
         with:
           version: latest
-          args: release --rm-dist --skip-validate
+          args: release --clean --skip=validate
         env:
           RUNNER_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ secrets.DOODLE_OSS_BOT}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin
+xunpack
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
+.vscode
+.idea
+*.swp
+*.swo
+*~

--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -26,11 +26,9 @@ import (
 	"encoding/json"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
 )
@@ -100,10 +98,6 @@ func ForCompositeResourceClaim(xrd *v1.CompositeResourceDefinition) (*extv1.Cust
 
 	crd.SetName(xrd.Spec.ClaimNames.Plural + "." + xrd.Spec.Group)
 	setCrdMetadata(crd, xrd)
-	crd.SetOwnerReferences([]metav1.OwnerReference{meta.AsController(
-		meta.TypedReferenceTo(xrd, v1.CompositeResourceDefinitionGroupVersionKind),
-	)})
-
 	crd.Spec.Names.Categories = append(crd.Spec.Names.Categories, CategoryClaim)
 
 	for i, vr := range xrd.Spec.Versions {

--- a/internal/xcrd/crd.go
+++ b/internal/xcrd/crd.go
@@ -64,10 +64,6 @@ func ForCompositeResource(xrd *v1.CompositeResourceDefinition) (*extv1.CustomRes
 
 	crd.SetName(xrd.GetName())
 	setCrdMetadata(crd, xrd)
-	crd.SetOwnerReferences([]metav1.OwnerReference{meta.AsController(
-		meta.TypedReferenceTo(xrd, v1.CompositeResourceDefinitionGroupVersionKind),
-	)})
-
 	crd.Spec.Names.Categories = append(crd.Spec.Names.Categories, CategoryComposite)
 
 	for i, vr := range xrd.Spec.Versions {

--- a/internal/xcrd/crd_test.go
+++ b/internal/xcrd/crd_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
 	v1 "github.com/crossplane/crossplane/apis/apiextensions/v1"
@@ -163,9 +162,6 @@ func TestForCompositeResource(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
-			OwnerReferences: []metav1.OwnerReference{
-				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
-			},
 		},
 		Spec: extv1.CustomResourceDefinitionSpec{
 			Group: group,
@@ -477,9 +473,6 @@ func TestForCompositeResourceEmptyXrd(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
 			Labels: labels,
-			OwnerReferences: []metav1.OwnerReference{
-				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
-			},
 		},
 		Spec: extv1.CustomResourceDefinitionSpec{
 			Group: group,
@@ -925,9 +918,6 @@ func TestForCompositeResourceClaim(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   claimPlural + "." + group,
 			Labels: labels,
-			OwnerReferences: []metav1.OwnerReference{
-				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
-			},
 		},
 		Spec: extv1.CustomResourceDefinitionSpec{
 			Group: group,
@@ -1227,9 +1217,6 @@ func TestForCompositeResourceClaimEmptyXrd(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   claimPlural + "." + group,
 			Labels: labels,
-			OwnerReferences: []metav1.OwnerReference{
-				meta.AsController(meta.TypedReferenceTo(d, v1.CompositeResourceDefinitionGroupVersionKind)),
-			},
 		},
 		Spec: extv1.CustomResourceDefinitionSpec{
 			Group: group,


### PR DESCRIPTION
## Current situation
xunpack adds ownerrefs to converted crd's from xrds'. This is not wanted as the ref is also invalid as it contains an empty uid.

## Proposal
Remove owner refs.
